### PR TITLE
Fixed a locking race condition

### DIFF
--- a/spec/delayed/backend/sequel_spec.rb
+++ b/spec/delayed/backend/sequel_spec.rb
@@ -26,6 +26,14 @@ describe Delayed::Backend::Sequel::Job do
     end
   end
 
+  describe "claim_job" do
+    it "return nil if the job already claimed by other worker" do
+      now = DateTime.now
+      job = described_class.create(:payload_object => SimpleJob.new, :locked_at => DateTime.now)
+      Delayed::Backend::Sequel::Job.claim_job(job, now, "the_worker_name").should be_nil
+    end
+  end
+
   context "db_time_now" do
     it "should return time in current time zone if set" do
       Time.zone = "Eastern Time (US & Canada)"


### PR DESCRIPTION
We found a race condition where two workers would occasionally both complete the same job. The first worker to finish the job finishes successfully, but the second worker would try to delete the job (thinking it finished successfully) and that worker process would crash as a result.

This pull request addresses this race condition.
