### PR TITLE
Add delayed_job 4.2 support

### DIFF
--- a/delayed_job_sequel.gemspec
+++ b/delayed_job_sequel.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |s|
   s.name              = "talentbox-delayed_job_sequel"
   s.version           = "4.3.0"
@@ -15,10 +13,9 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.test_files        = Dir.glob("spec/**/*")
 
-  s.add_runtime_dependency      "sequel", [">= 3.38", "< 6.0"]
-  s.add_runtime_dependency      "delayed_job", "~> 4.1.0"
-  s.add_runtime_dependency      "tzinfo"
+  s.add_runtime_dependency "sequel", [">= 3.38", "< 6.0"]
+  s.add_runtime_dependency "delayed_job", "~> 4.1"
 
-  s.add_development_dependency  "rspec", "~> 3.6.0"
-  s.add_development_dependency  "rake"
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "rake"
 end

--- a/spec/delayed/serialization/sequel_spec.rb
+++ b/spec/delayed/serialization/sequel_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Sequel::Model do
   it 'should load classes with non-default primary key' do
     expect do
-      YAML.load(Story.create.to_yaml)
+      YAML.safe_load(Story.create.to_yaml, permitted_classes: [Story, Symbol])
     end.not_to raise_error
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,4 +83,7 @@ class Story < Sequel::Model
   end
   handle_asynchronously :whatever
   alias_method :persisted?, :exists?
+  def save!
+    save(raise_on_failure: true)
+  end
 end


### PR DESCRIPTION
This loosens the version requirements for `delayed_job` gem and fixes broken specs.

I also removed `tzinfo` as a dependency since I couldn't find evidence of it being used anywhere.